### PR TITLE
Use Turbopack for the e2e build instead of webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "currencies": "pnpm ts-node -O '{\"module\":\"commonjs\"}' ./app/scripts/currencies.ts",
     "dev": "pnpm ts-node -O '{\"module\":\"commonjs\"}' ./app/scripts/serve.ts dev",
     "build": "next build",
-    "build:e2e": "E2E_LEAN_BUILD=1 next build --webpack",
+    "build:e2e": "E2E_LEAN_BUILD=1 next build",
     "start": "pnpm ts-node -O '{\"module\":\"commonjs\"}' ./app/scripts/serve.ts start",
     "lint": "next typegen && tsc --noemit; eslint .",
     "prisma-build": "pnpm prisma generate",


### PR DESCRIPTION
build:e2e was set to `next build --webpack` on the theory that a webpack build has a lower peak-memory footprint and is thus less likely to be OOM-killed (SIGKILL/137) during Playwright globalSetup. That traded the default bundler for an unproven memory win, and the webpack build breaks on the HeroUI/Next 16 stack.

Revert to Turbopack (the default, matching `build`) and keep only the bundler-agnostic memory lever: E2E_LEAN_BUILD=1, which next.config.js reads to disable productionBrowserSourceMaps (the largest reliable contributor to build peak memory).